### PR TITLE
chore: update CI badge to track pull_request events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Daniel Kindl Portfolio
 
-[![CI](https://img.shields.io/github/actions/workflow/status/daniel-kindl/daniel-kindl.github.io/ci.yml?branch=master&label=CI&logo=githubactions&logoColor=white)](https://github.com/daniel-kindl/daniel-kindl.github.io/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/daniel-kindl/daniel-kindl.github.io/ci.yml?event=pull_request&label=CI&logo=githubactions&logoColor=white)](https://github.com/daniel-kindl/daniel-kindl.github.io/actions/workflows/ci.yml)
 [![Deploy](https://img.shields.io/github/actions/workflow/status/daniel-kindl/daniel-kindl.github.io/deploy.yml?branch=master&label=Deploy&logo=githubactions&logoColor=white)](https://github.com/daniel-kindl/daniel-kindl.github.io/actions/workflows/deploy.yml)
 [![Astro](https://img.shields.io/badge/Astro-7-BC52EE?logo=astro&logoColor=white)](https://astro.build)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)


### PR DESCRIPTION
Updates the CI status badge in the README to report on pull request workflow runs instead of the master branch.

**Changes:**
- Modified the CI badge URL parameter from `branch=master` to `event=pull_request`, so the badge reflects the status of CI checks running on PRs rather than the latest master branch build

**Rationale:**
This aligns the badge display with the actual CI workflow behavior defined in `.github/workflows/ci.yml`, which runs on pull requests to `master`. The badge now accurately represents whether incoming PRs pass CI checks, which is more relevant for contributors and reviewers than the master branch status (which is gated by the separate deploy workflow).

https://claude.ai/code/session_01RwW997qfoNRApKamXx58DX