### PR TITLE
fix: clarify portfolio messaging

### DIFF
--- a/src/components/portfolio/ProjectCard.astro
+++ b/src/components/portfolio/ProjectCard.astro
@@ -36,6 +36,9 @@ const hiddenStackCount = project.data.stack.length - visibleStack.length;
     <Typography variant="body" class="mb-6 max-w-xl text-(--text-muted)">
       {project.data.summary}
     </Typography>
+    <div class="mb-4 font-mono text-[10px] text-(--text-muted) uppercase md:hidden">
+      Status: {getProjectStatusLabel(project.data.status)} · Timeline: {timelineLabel}
+    </div>
     <div class="mb-6 flex flex-wrap gap-2">
       {visibleStack.map((tech: string) => <Tag label={tech} />)}
       {hiddenStackCount > 0 && <Tag label={`+${hiddenStackCount} more`} />}
@@ -50,9 +53,6 @@ const hiddenStackCount = project.data.stack.length - visibleStack.length;
         )
       }
     </div>
-    <div class="mt-4 font-mono text-[10px] text-(--text-muted) uppercase md:hidden">
-      Status: {getProjectStatusLabel(project.data.status)} · Timeline: {timelineLabel}
-    </div>
   </div>
 
   <div
@@ -62,7 +62,7 @@ const hiddenStackCount = project.data.stack.length - visibleStack.length;
       <div>Status: {getProjectStatusLabel(project.data.status)}</div>
       <div>Timeline: {timelineLabel}</div>
       <div>
-        Stack: {project.data.stack.length}
+        Stack: {project.data.stack.length}{' '}
         {project.data.stack.length === 1 ? 'technology' : 'technologies'}
       </div>
     </div>

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -5,7 +5,7 @@ const careerStartDate = new Date('2023-07-01');
 export const technicalProfile = {
   name: 'Daniel Kindl',
   role: 'Software Engineer',
-  summary: `${getYearsOfExperience(careerStartDate)}+ years building software with C#/.NET, Kotlin, Go, and TypeScript. Most of my work has been desktop applications and backend services, alongside Android apps, web projects, and developer tools.`,
+  summary: `Software engineer who likes turning ideas and annoying problems into finished software. ${getYearsOfExperience(careerStartDate)}+ years building software with C#/.NET, Kotlin, Go, and TypeScript. Most of my work has been desktop applications and backend services, alongside Android apps, web projects, and developer tools.`,
   skills: {
     languages: ['C#', 'Go', 'TypeScript', 'JavaScript', 'Delphi'],
     frameworks: ['.NET', 'Android'],

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,7 +14,7 @@ interface Props {
 
 const {
   title,
-  description = 'Software engineer who designs systems, then builds them — combining hands-on engineering experience with AI-assisted development to ship and maintain production software.',
+  description = 'Software engineer building and shipping useful software across platforms. I choose the tools that fit the problem.',
   ogImage = '/assets/meta/og-default.png',
 }: Props = Astro.props;
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -70,7 +70,7 @@ const skillGroups = [
     <section class="max-w-4xl">
       <div class="mb-8">
         <Typography variant="eyebrow">Skills</Typography>
-        <Typography variant="h2">Core Technical Stack</Typography>
+        <Typography variant="h2">Technical Toolkit</Typography>
       </div>
       <div class="grid gap-8 md:grid-cols-2">
         {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,8 +25,8 @@ const recentPosts = allPosts.slice(0, 2);
         I design systems, <span class="text-(--text-muted)">then build them</span>.
       </Typography>
       <Typography variant="body" class="mb-6 max-w-xl text-(--text-muted)">
-        I combine hands-on engineering experience with AI-assisted development to build software,
-        ship it, and keep it running well over time.
+        Software engineer building and shipping useful software across platforms. I choose the tools
+        that fit the problem.
       </Typography>
       <Typography variant="mono" class="mb-12 block text-(--text-muted)">
         [{allProjects.length} shipped projects · {allPosts.length} engineering write-ups]
@@ -96,9 +96,9 @@ const recentPosts = allPosts.slice(0, 2);
       <Typography variant="eyebrow">How I Work</Typography>
       <Typography variant="h2" class="mb-4">Good development starts with structure</Typography>
       <Typography variant="body" class="mb-6 text-(--text-muted)">
-        I like structure. Good DevOps and a dependable platform are the beginning of good
-        development. When builds, tests, and releases are predictable, the code is easier to change
-        and maintain.
+        I like structure. Good DevOps and a dependable platform make it easier to take software from
+        an idea to a release, then keep improving it over time. When builds, tests, and releases are
+        predictable, the code is easier to change and maintain.
       </Typography>
       <Button href={mailto} variant="primary">Get in touch</Button>
     </div>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -11,14 +11,14 @@ const sortedProjects = await getSortedProjects();
 
 <Layout
   title={pageTitle('Projects')}
-  description="Selected projects across developer tooling and web development."
+  description="Here are a few things I’ve built: apps, tools, websites, and experiments."
 >
   <Container class="py-12 md:py-20">
     <header class="mb-12">
       <Typography variant="eyebrow">Projects</Typography>
       <Typography variant="h1" class="mb-4">Selected Engineering Work</Typography>
       <Typography variant="body" class="max-w-2xl text-(--text-muted)">
-        Selected projects across developer tooling and web development.
+        Here are a few things I’ve built: apps, tools, websites, and experiments.
       </Typography>
     </header>
 

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -52,6 +52,7 @@ const linkLabels = [
 
 <Layout
   title={`${project.data.title} — Case Study`}
+  description={project.data.summary}
   ogImage={`/assets/meta/og/projects/${project.id}.png`}
 >
   <article data-pagefind-body>
@@ -66,9 +67,6 @@ const linkLabels = [
         <Typography variant="h1" class="mb-6 max-w-4xl">
           {project.data.title}
         </Typography>
-        <div class="mb-6 flex flex-wrap gap-2">
-          {project.data.stack.map((tech: string) => <Tag label={tech} />)}
-        </div>
         <div class="flex flex-wrap gap-3">
           {
             project.data.links?.repository && (
@@ -100,6 +98,10 @@ const linkLabels = [
               </ExternalLink>
             )
           }
+        </div>
+        <div class="mt-6 flex flex-wrap items-center gap-2">
+          <span class="mr-1 font-mono text-[10px] text-(--text-muted) uppercase">Built with</span>
+          {project.data.stack.map((tech: string) => <Tag label={tech} />)}
         </div>
       </Container>
     </div>


### PR DESCRIPTION
## Summary

- Reframe the homepage and shared metadata around building, shipping, and choosing tools for the problem.
- Add problem-first positioning to the About page and make the technical stack a secondary “Technical Toolkit”.
- Replace the Projects page description with plain first-person copy: “Here are a few things I’ve built: apps, tools, websites, and experiments.”
- Put project status and timeline before stack tags on cards.
- Move case-study stack tags below the project links and label them “Built with”.
- Leave all project MDX files and writing posts unchanged.

## Why

The previous copy sounded generic and technology-led. This makes the site read more like Daniel’s own portfolio while preserving the existing structure and factual content.

## Validation

- `npm run lint`
- `npm run format:check`
- `ASTRO_TELEMETRY_DISABLED=1 npm run typecheck`
- `npm test` — 23 tests passed
- `ASTRO_TELEMETRY_DISABLED=1 npm run build` — 37 pages built